### PR TITLE
Raise RetryErrors if they exist at all

### DIFF
--- a/Products/SimpleUserFolder/SimpleUserFolder.py
+++ b/Products/SimpleUserFolder/SimpleUserFolder.py
@@ -14,6 +14,12 @@ from Shared.DC.ZRDB.Results import Results
 from .User import User
 from zExceptions import Redirect
 
+try:
+    from Zope2.App.startup import RetryError
+except ImportError:
+    # If the retry feature is not present, ignore it.
+    RetryError = None
+
 import logging
 
 ManageUsersPermission = 'Manage users'
@@ -139,6 +145,8 @@ class SimpleUserFolder(ObjectManager, BasicUserFolder):
                 auth_name, auth_password = BasicUserFolder.identify(self, auth)
             try:
                 username = getAuth(name=auth_name, password=auth_password)
+            except RetryError:
+                raise
             except Exception as err:
                 # raise
                 logger.warn('Problem with getAuth detected!')


### PR DESCRIPTION
The aim of this PR is to make errors in SimpleUserFolder respect the RetryError feature added to Zope2.App as part of a PerFact patch.