### PR TITLE
Do not fall back to BasicUserFolder authentication.

### DIFF
--- a/Products/SimpleUserFolder/SimpleUserFolder.py
+++ b/Products/SimpleUserFolder/SimpleUserFolder.py
@@ -157,8 +157,7 @@ class SimpleUserFolder(ObjectManager, BasicUserFolder):
             if username:
                 user = self.getUser(username)
         if not user:
-            basic = BasicUserFolder.validate(self, request, auth, roles)
-            return basic
+            return None
 
         # The following code snippet is taken from BasicUserFolder:
         request._auth = 'basic %s:hiddenpw' % username

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '0.1+perfact.2'
+version = '0.1+perfact.3'
 
 setup(name='Products.SimpleUserFolder',
       version=version,


### PR DESCRIPTION
Otherwise, if getUserDetails in the BasicUserFolder happens to return
the password hash of a user that is actually denied access by
getUserAuthorization (for example, because the user is disabled), access
will still be granted if using Basic authentication.